### PR TITLE
Fix problem with palette tRNS handling on Python 3

### DIFF
--- a/code/png/png.py
+++ b/code/png/png.py
@@ -2519,7 +2519,7 @@ class Reader(object):
                 "Required PLTE chunk is missing in colour type 3 image.")
         plte = group(bytearray(self.plte), 3)
         if self.trns or alpha == 'force':
-            trns = bytearray(self.trns or '')
+            trns = bytearray(self.trns or b'')
             trns.extend([255]*(len(plte)-len(trns)))
             plte = list(map(operator.add, plte, group(trns, 1)))
         return plte


### PR DESCRIPTION
Crashed on Python 3 with "TypeError: string argument without an encoding"