### PR TITLE
Python 3.7 / PEP 479 compliance fix for iterator nestedly raising StopIteration

### DIFF
--- a/png/png.py
+++ b/png/png.py
@@ -325,9 +325,16 @@ def peekiter(iterable):
 
     def gen():
         """Generator that returns first and proxy other items from source"""
-        yield one
+        try:
+            yield one
+        except StopIteration:
+            return
+
         while True:
-            yield next(it)
+            try:
+                yield next(it)
+            except StopIteration:
+                break
     return (one, gen())
 
 


### PR DESCRIPTION
`peekiter()` raises `StopIteration` from within a nested generator, this behavior was soft deprecated in Python 3.6 and hard deprecated in Python 3.7. (I found out because some code broke ;))

Fixes the following `DeprecationWarning` in Python 3.6:
```
python test_png.py 
...................purepng/png/png.py:1480: DeprecationWarning: generator 'peekiter.<locals>.gen' raised StopIteration
  for i, row in enumrows:
.........................................................purepng/png/png.py:1318: DeprecationWarning: generator 'peekiter.<locals>.gen' raised StopIteration
  for row in inrows:
.......
----------------------------------------------------------------------
Ran 83 tests in 3.169s

OK
```

And a uncaught exception in Python 3.7…