### PR TITLE
Fix iTXt compression_flag off-by-one error

### DIFF
--- a/png/png.py
+++ b/png/png.py
@@ -2582,11 +2582,13 @@ class Reader(object):
             keyword = str(keyword, 'latin-1')
         except:
             pass
-        if (data[i:i + 1] != zerobyte):
+        compression_flag = data[i + 1: i + 2]
+        if (compression_flag != zerobyte):
             # TODO: Support for compression!!
             return
         # TODO: Raise FormatError
-        assert (data[i + 1:i + 2] == zerobyte)
+        compression_method = data[i + 2:i + 3]
+        assert (compression_method == zerobyte)
         data_ = data[i + 3:]
         i = data_.index(zerobyte)
         # skip language tag


### PR DESCRIPTION
According to http://www.w3.org/TR/PNG/#11iTXt the byte after the first instance of null separator (`zerobyte`) is used to indicate that the text content is compressed - the compression flag.

This fixes a bug where the null separator index is used by accident when checking for the compression flag.